### PR TITLE
Add PDF MIME sniffing and structured text extraction

### DIFF
--- a/agents/ingest/__init__.py
+++ b/agents/ingest/__init__.py
@@ -1,0 +1,12 @@
+"""Ingest helper utilities and public API surface."""
+
+from .pdf_text import PdfTextExtraction, extract_pdf_text
+from .sniff_mime import PageFeature, SniffResult, sniff_path
+
+__all__ = [
+    "PdfTextExtraction",
+    "PageFeature",
+    "SniffResult",
+    "extract_pdf_text",
+    "sniff_path",
+]

--- a/agents/ingest/pdf_text.py
+++ b/agents/ingest/pdf_text.py
@@ -1,0 +1,198 @@
+"""Structured PDF text extraction built on top of PyMuPDF."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable, List
+
+from .sniff_mime import compute_page_features
+
+try:  # pragma: no cover - import guarded for environments without PyMuPDF
+    import fitz  # type: ignore
+except ImportError:  # pragma: no cover
+    fitz = None  # type: ignore[assignment]
+
+
+BBox = tuple[float, float, float, float]
+
+
+@dataclass(slots=True)
+class WordSpan:
+    """A single token extracted from a PDF page."""
+
+    text: str
+    bbox: BBox
+    block_index: int
+    line_index: int
+    word_index: int
+
+
+@dataclass(slots=True)
+class LineSpan:
+    """A logical line containing one or more words."""
+
+    text: str
+    bbox: BBox
+    block_index: int
+    line_index: int
+    words: List[WordSpan] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class BlockSpan:
+    """Higher-level block (paragraph, table cell, etc.)."""
+
+    text: str
+    bbox: BBox
+    block_index: int
+    lines: List[LineSpan] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class PageExtraction:
+    """Per-page representation of text, geometry, and layout features."""
+
+    page_number: int
+    text: str
+    blocks: List[BlockSpan]
+    word_count: int
+    glyph_count: int
+    text_density: float
+    image_fraction: float
+
+
+@dataclass(slots=True)
+class PdfTextExtraction:
+    """Container for a PDF's textual content."""
+
+    pages: List[PageExtraction] = field(default_factory=list)
+    scan_score: float = 0.0
+    likely_scanned: bool = False
+
+
+def extract_pdf_text(path: Path, *, sort: bool = True) -> PdfTextExtraction:
+    """Extract structured text and layout metadata from a PDF."""
+
+    if fitz is None:  # pragma: no cover
+        raise RuntimeError("PyMuPDF is required to extract PDF text.")
+
+    document = fitz.open(path)  # type: ignore[call-arg]
+    pages: List[PageExtraction] = []
+    for page in document:
+        page_feature = compute_page_features(page, sort_words=sort)
+        blocks = _build_block_structure(page, sort=sort)
+        page_text = "\n".join(block.text for block in blocks if block.text).strip()
+        pages.append(
+            PageExtraction(
+                page_number=page.number + 1,
+                text=page_text,
+                blocks=blocks,
+                word_count=page_feature.word_count,
+                glyph_count=page_feature.glyph_count,
+                text_density=page_feature.text_density,
+                image_fraction=page_feature.image_fraction,
+            )
+        )
+
+    scan_score, likely_scanned = _estimate_scan_likelihood(pages)
+    return PdfTextExtraction(pages=pages, scan_score=scan_score, likely_scanned=likely_scanned)
+
+
+def _build_block_structure(page: "fitz.Page", *, sort: bool = True) -> List[BlockSpan]:
+    """Reconstruct the block/line/word hierarchy from PyMuPDF output."""
+
+    words = page.get_text("words", sort=sort)
+    block_map: dict[int, dict[int, List[WordSpan]]] = {}
+    bbox_map: dict[tuple[int, int], List[float]] = {}
+
+    for x0, y0, x1, y1, text, block_no, line_no, word_no in words:
+        bbox = (float(x0), float(y0), float(x1), float(y1))
+        block_idx = int(block_no)
+        line_idx = int(line_no)
+        word_idx = int(word_no)
+        span = WordSpan(
+            text=str(text),
+            bbox=bbox,
+            block_index=block_idx,
+            line_index=line_idx,
+            word_index=word_idx,
+        )
+        block_map.setdefault(block_idx, {}).setdefault(line_idx, []).append(span)
+        bbox_map.setdefault((block_idx, line_idx), []).extend([bbox[0], bbox[1], bbox[2], bbox[3]])
+
+    blocks: List[BlockSpan] = []
+    for block_idx in sorted(block_map.keys()):
+        line_spans: List[LineSpan] = []
+        for line_idx in sorted(block_map[block_idx].keys()):
+            word_spans = sorted(block_map[block_idx][line_idx], key=lambda w: w.word_index)
+            line_text = " ".join(word.text for word in word_spans).strip()
+            coords = bbox_map[(block_idx, line_idx)]
+            x_coords = coords[0::4]
+            y_coords = coords[1::4]
+            x2_coords = coords[2::4]
+            y2_coords = coords[3::4]
+            line_bbox = (
+                min(x_coords) if x_coords else 0.0,
+                min(y_coords) if y_coords else 0.0,
+                max(x2_coords) if x2_coords else 0.0,
+                max(y2_coords) if y2_coords else 0.0,
+            )
+            line_spans.append(
+                LineSpan(
+                    text=line_text,
+                    bbox=line_bbox,
+                    block_index=block_idx,
+                    line_index=line_idx,
+                    words=word_spans,
+                )
+            )
+        if not line_spans:
+            continue
+        block_bbox = _union_bbox(span.bbox for span in line_spans)
+        block_text = "\n".join(line.text for line in line_spans if line.text)
+        blocks.append(
+            BlockSpan(
+                text=block_text,
+                bbox=block_bbox,
+                block_index=block_idx,
+                lines=line_spans,
+            )
+        )
+
+    return blocks
+
+
+def _union_bbox(bboxes: Iterable[BBox]) -> BBox:
+    """Return the bounding box that encloses all supplied boxes."""
+
+    xs0: List[float] = []
+    ys0: List[float] = []
+    xs1: List[float] = []
+    ys1: List[float] = []
+    for x0, y0, x1, y1 in bboxes:
+        xs0.append(float(x0))
+        ys0.append(float(y0))
+        xs1.append(float(x1))
+        ys1.append(float(y1))
+    if not xs0:
+        return (0.0, 0.0, 0.0, 0.0)
+    return (min(xs0), min(ys0), max(xs1), max(ys1))
+
+
+def _estimate_scan_likelihood(pages: List[PageExtraction]) -> tuple[float, bool]:
+    """Heuristic scoring for identifying likely scanned documents."""
+
+    if not pages:
+        return 0.0, False
+
+    avg_image_fraction = sum(page.image_fraction for page in pages) / len(pages)
+    sparse_pages = [page for page in pages if page.glyph_count < 50]
+    low_density_pages = [page for page in pages if page.text_density < 0.02]
+
+    sparse_ratio = len(sparse_pages) / len(pages)
+    low_density_ratio = len(low_density_pages) / len(pages)
+
+    score = 0.5 * avg_image_fraction + 0.3 * sparse_ratio + 0.2 * low_density_ratio
+    score = min(1.0, score)
+    likely_scanned = score >= 0.5
+    return score, likely_scanned

--- a/agents/ingest/sniff_mime.py
+++ b/agents/ingest/sniff_mime.py
@@ -1,0 +1,180 @@
+"""Document type sniffing and lightweight PDF layout features."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import mimetypes
+from pathlib import Path
+from typing import Literal, Optional
+
+try:  # pragma: no cover - import guarded for environments without PyMuPDF
+    import fitz  # type: ignore
+except ImportError:  # pragma: no cover
+    fitz = None  # type: ignore[assignment]
+
+
+BBox = tuple[float, float, float, float]
+DocumentKind = Literal["pdf", "image", "spreadsheet", "text", "unknown"]
+
+
+@dataclass(slots=True)
+class PageFeature:
+    """Lightweight statistics computed per PDF page."""
+
+    page_number: int
+    word_count: int
+    glyph_count: int
+    text_area: float
+    page_area: float
+    image_area: float
+
+    @property
+    def text_density(self) -> float:
+        """Density of text coverage on the page (0.0 – 1.0)."""
+
+        if self.page_area <= 0:
+            return 0.0
+        return min(1.0, self.text_area / self.page_area)
+
+    @property
+    def image_fraction(self) -> float:
+        """Fraction of the page covered by raster images (0.0 – 1.0)."""
+
+        if self.page_area <= 0:
+            return 0.0
+        return min(1.0, self.image_area / self.page_area)
+
+
+@dataclass(slots=True)
+class SniffResult:
+    """Result from sniffing a document path."""
+
+    path: Path
+    mime_type: Optional[str]
+    kind: DocumentKind
+    page_features: list[PageFeature] = field(default_factory=list)
+
+    def is_pdf(self) -> bool:
+        return self.kind == "pdf"
+
+
+_PDF_SIGNATURE = b"%PDF"
+
+_IMAGE_EXTS = {
+    ".png",
+    ".jpg",
+    ".jpeg",
+    ".tif",
+    ".tiff",
+    ".bmp",
+    ".gif",
+    ".webp",
+}
+
+_SPREADSHEET_EXTS = {
+    ".csv",
+    ".tsv",
+    ".xls",
+    ".xlsx",
+    ".xlsm",
+    ".ods",
+}
+
+_TEXT_EXTS = {".txt", ".md", ".rtf"}
+
+
+def sniff_path(path: Path, *, sort_words: bool = True) -> SniffResult:
+    """Identify the document type and compute coarse PDF layout features."""
+
+    if not path.exists():
+        raise FileNotFoundError(path)
+
+    suffix = path.suffix.lower()
+    mime_type, _ = mimetypes.guess_type(path.name)
+
+    if _looks_like_pdf(path):
+        if fitz is None:  # pragma: no cover
+            raise RuntimeError("PyMuPDF is required to analyze PDF documents.")
+        document = fitz.open(path)  # type: ignore[call-arg]
+        page_features = [
+            compute_page_features(page, sort_words=sort_words)
+            for page in document
+        ]
+        return SniffResult(path=path, mime_type=mime_type or "application/pdf", kind="pdf", page_features=page_features)
+
+    if suffix in _IMAGE_EXTS:
+        return SniffResult(path=path, mime_type=mime_type or "image/unknown", kind="image")
+
+    if suffix in _SPREADSHEET_EXTS:
+        if suffix == ".csv":
+            mime_type = mime_type or "text/csv"
+        elif suffix == ".tsv":
+            mime_type = mime_type or "text/tab-separated-values"
+        else:
+            mime_type = (
+                mime_type
+                or "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+            )
+        return SniffResult(path=path, mime_type=mime_type, kind="spreadsheet")
+
+    if suffix in _TEXT_EXTS:
+        return SniffResult(path=path, mime_type=mime_type or "text/plain", kind="text")
+
+    if mime_type == "application/pdf":
+        if fitz is None:  # pragma: no cover
+            raise RuntimeError("PyMuPDF is required to analyze PDF documents.")
+        document = fitz.open(path)  # type: ignore[call-arg]
+        page_features = [
+            compute_page_features(page, sort_words=sort_words)
+            for page in document
+        ]
+        return SniffResult(path=path, mime_type=mime_type, kind="pdf", page_features=page_features)
+
+    return SniffResult(path=path, mime_type=mime_type, kind="unknown")
+
+
+def compute_page_features(page: "fitz.Page", *, sort_words: bool = True) -> PageFeature:
+    """Compute text and image coverage statistics for a PyMuPDF page."""
+
+    page_area = float(page.rect.width * page.rect.height)
+    word_count = 0
+    glyph_count = 0
+    text_area = 0.0
+    for word in page.get_text("words", sort=sort_words):
+        x0, y0, x1, y1, text, *_ = word
+        width = max(0.0, float(x1) - float(x0))
+        height = max(0.0, float(y1) - float(y0))
+        text_area += width * height
+        word_count += 1
+        glyph_count += len(text.strip())
+
+    image_area = 0.0
+    try:
+        blocks = page.get_text("dict", sort=sort_words)["blocks"]
+    except RuntimeError:
+        blocks = []
+    for block in blocks:
+        if block.get("type") == 1:
+            x0, y0, x1, y1 = block.get("bbox", (0.0, 0.0, 0.0, 0.0))
+            width = max(0.0, float(x1) - float(x0))
+            height = max(0.0, float(y1) - float(y0))
+            image_area += width * height
+
+    return PageFeature(
+        page_number=page.number + 1,
+        word_count=word_count,
+        glyph_count=glyph_count,
+        text_area=text_area,
+        page_area=page_area,
+        image_area=image_area,
+    )
+
+
+def _looks_like_pdf(path: Path) -> bool:
+    """Return True if the file extension or header suggests a PDF document."""
+
+    if path.suffix.lower() == ".pdf":
+        return True
+
+    with path.open("rb") as handle:
+        prefix = handle.read(len(_PDF_SIGNATURE))
+    return prefix.startswith(_PDF_SIGNATURE)

--- a/tests/unit/test_pdf_ingest.py
+++ b/tests/unit/test_pdf_ingest.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+
+import fitz
+
+from agents.ingest.pdf_text import extract_pdf_text
+from agents.ingest.sniff_mime import sniff_path
+
+
+_PIXEL_PNG = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAukB9pXt1l0AAAAASUVORK5CYII="
+)
+
+
+def _make_text_pdf(tmp_path: Path) -> Path:
+    doc = fitz.open()
+    page = doc.new_page(width=612, height=792)
+    page.insert_text((72, 72), "Header", fontsize=16)
+    page.insert_text((72, 144), "left one\nleft two", fontsize=12)
+    page.insert_text((300, 144), "right one\nright two", fontsize=12)
+    path = tmp_path / "layout.pdf"
+    doc.save(path)
+    return path
+
+
+def _make_scanned_pdf(tmp_path: Path) -> Path:
+    doc = fitz.open()
+    page = doc.new_page(width=612, height=792)
+    pix = fitz.Pixmap(fitz.csRGB, (0, 0, 400, 600), 0)
+    pix.clear_with(255)
+    page.insert_image(page.rect, pixmap=pix)
+    path = tmp_path / "scan.pdf"
+    doc.save(path)
+    return path
+
+
+def test_sniff_mime_pdf_features(tmp_path):
+    pdf_path = _make_text_pdf(tmp_path)
+    result = sniff_path(pdf_path)
+
+    assert result.kind == "pdf"
+    assert len(result.page_features) == 1
+
+    page_feature = result.page_features[0]
+    assert page_feature.word_count == 9
+    assert page_feature.text_density > 0
+    assert page_feature.image_fraction == 0
+
+
+def test_sniff_mime_identifies_other_types(tmp_path):
+    csv_path = tmp_path / "data.csv"
+    csv_path.write_text("col1,col2\n1,2\n")
+    csv_result = sniff_path(csv_path)
+    assert csv_result.kind == "spreadsheet"
+
+    png_path = tmp_path / "image.png"
+    png_path.write_bytes(_PIXEL_PNG)
+    image_result = sniff_path(png_path)
+    assert image_result.kind == "image"
+
+
+def test_extract_pdf_text_structure_sorted(tmp_path):
+    pdf_path = _make_text_pdf(tmp_path)
+    extraction = extract_pdf_text(pdf_path, sort=True)
+
+    assert len(extraction.pages) == 1
+    page = extraction.pages[0]
+    block_texts = [block.text for block in page.blocks]
+    assert block_texts == ["Header", "left one\nleft two", "right one\nright two"]
+    assert page.word_count == 9
+    assert page.glyph_count == len("Headerleft oneleft tworight oneright two".replace(" ", ""))
+
+
+def test_scanned_pdf_detection(tmp_path):
+    pdf_path = _make_scanned_pdf(tmp_path)
+    extraction = extract_pdf_text(pdf_path)
+
+    assert extraction.pages[0].image_fraction > 0.8
+    assert extraction.likely_scanned is True
+    assert extraction.scan_score >= 0.5


### PR DESCRIPTION
## Summary
- add a MIME sniffer that classifies PDFs, spreadsheets, and images while computing page-level text and image coverage metrics
- implement a PyMuPDF-based text extractor that preserves block/line/word geometry and flags likely scanned documents
- cover the new ingest utilities with pytest-based layout and scan detection tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7a8d079f88332b74ae92a4084cc43